### PR TITLE
Update README.md to remove references to R Studio

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -34,7 +34,6 @@ After cloning the git repo:
 
 `datakit data pull` to rerieve the data files.
 
-Open `{{ cookiecutter.project_slug }}.Rproj` in RStudio.
 
 *TK: For more complex or unusual projects additional directions follow*
 


### PR DESCRIPTION
As this is a Python cookiecutter, users won't be working with the data in R (most likely)