### PR TITLE
Add kernel tweak to post-creation hook

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -11,3 +11,22 @@ echo -e "\nexport_html_notebook = \"jupyter-nbconvert --to html --template ap_re
 ## This is meant to be run when people first clone the project.
 ## We run it here to get the benefit of installing the ipython kernel.
 pipenv run first_install
+
+## Set kernels to run from where git was initialized (the project root)
+## If git wasn't initialized, notebooks run from where the notebook file is (the default)
+
+JUPYTER_DATA_DIR=$(jupyter --data-dir)
+KERNEL_PATH=$JUPYTER_DATA_DIR/kernels/{{cookiecutter.project_slug}}
+VENV_DIR=$(pipenv --venv)
+
+## Replace the default kernel.json with one that points to kernel.sh
+echo -e '{\n "argv": [' > $KERNEL_PATH/kernel.json
+echo "  \"$KERNEL_PATH/kernel.sh\"," >> $KERNEL_PATH/kernel.json
+echo -e '  "{connection_file}"\n ],\n "display_name": "{{cookiecutter.project_slug}}",\n "language":"python",\n "metadata":{\n "debugger":true\n }\n}' >> $KERNEL_PATH/kernel.json
+
+## kernel.sh first changes directory to git root before invoking the default command to launch a kernel
+echo -e '#!/bin/bash\ncd "$(git rev-parse --show-toplevel)"' > $KERNEL_PATH/kernel.sh
+echo "exec $VENV_DIR/bin/python -m ipykernel_launcher -f \"\$1\"" >> $KERNEL_PATH/kernel.sh
+
+## Execute permissions
+chmod 777 $KERNEL_PATH/kernel.sh


### PR DESCRIPTION
Jupyter launches a kernel in order to 'run' a notebook. The configuration of
that kernel is located, generally, where `jupyter --data-dir` is, under the
`/kernels` subfolder. By default, the kernel launches the python binary found at
`pipenv --venv`; this modification adds a `cd` command to run before the python
binary, which makes sure that the python binary is launched from the project
root (here, the output of `git rev-parse --show-toplevel`.

If git is not initialized, the `cd` step fails and the python binary is launched
from the notebook location.

I don't know what happens if pipenv is not installed; I'm guessing the binary
won't be found, and the kernel will fail to start. Possible fix to that could be
to add a conditional that fails over to some systemwide Python install, but I
think we are expecting `pipenv` in other parts of this project template
anyway (as in issue #1).