### PR TITLE
fix jupyterlab version <=3.2.1.

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ## This post project generation script only runs if pipenv is on the machine
 command -v pipenv >/dev/null 2>&1 || { echo >&2 "pipenv not found.  Aborting startup script."; exit 1; }
-## Main installs typical to a project
-pipenv install ipython ipykernel pandas matplotlib notebook jupyterlab altair jupytext jupyterlab_templates
+## Main installs typical to a project & install working version of jupyterlab
+pipenv install ipython ipykernel pandas matplotlib notebook altair "jupyterlab<=3.2.1" jupytext jupyterlab_templates
 ## Add the first install script to the Pipfile
 echo -e "\n[scripts]\nfirst_install = \"python .first_install.py\"\nexport_rmarkdown = \"Rscript .export_rmarkdown.R\"" >> Pipfile
 ## Add script to render reports using AP nbconvert template


### PR DESCRIPTION
`datakit project create --template cookiecutter-python-project` broke because `pipenv install jupyterlab` installed the latest `version 3.2.4` which had errors when building jupyterlab (npm dependencies). This hot fix forces an pipenv install of jupyterlab to `version 3.2.1` or below.