### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ These steps assume configuration for [datakit-project](https://github.com/associ
 
 ```
 cd path/to/.cookiecutters
-git clone git@github.com/associatedpress/cookiecutter-python-project
+git clone git@github.com/associatedpress/cookiecutter-python-project.git
 ```
 
 - Now, when starting a new project with `datakit-project`, reference the cookiecutter in your filesystem. This creates a `pipenv` virtual environment and a ipython kernel for jupyter notebooks that will have the name of the `project_slug`.


### PR DESCRIPTION
Under the Usage section containing `If you'd like to keep a local version of this template on your computer, git clone this repository to where your cookiecutters live:` added .git to the end of the repo address. Command failed without it.